### PR TITLE
fix: impede que usuário avance para dia futuro

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,3 +1,6 @@
+
+const rightButton = document.getElementById('rightButton');
+
 const today = new Date(Date());
 today.setHours(3, 0, 0, 0);
 
@@ -15,6 +18,8 @@ function formatDate(date) {
   }
 
 function incrementDate() {
+    if (currentDate.toString() === today.toString())
+        return ;
     currentDate.setDate(currentDate.getDate()+1);
     updateDateDisplay();
     clearTable();
@@ -37,8 +42,12 @@ function updateDescription(text) {
 
 
 function updateDateDisplay() {
-  const displayDate = formatDate(currentDate);
-  document.getElementById("dateDisplay").textContent = displayDate;
+    const displayDate = formatDate(currentDate);
+    document.getElementById("dateDisplay").textContent = displayDate;
+    if (currentDate.toString() === today.toString())
+        rightButton.classList.add('disabled');
+    else if (rightButton.classList.contains('disabled'))
+        rightButton.classList.remove('disabled');
 }
 
 function sendRequest() {

--- a/static/styles.css
+++ b/static/styles.css
@@ -61,4 +61,7 @@
   button:focus {
     outline: none;
   }
-  
+
+  .disabled {
+    color: grey;
+  }

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,9 +31,9 @@
         </form>
         <div id="description"></div>
         <div class="date-switcher">
-          <button onclick="decrementDate()">&lt;</button>
+          <button id="leftButton" onclick="decrementDate()">&lt;</button>
           <span id="dateDisplay"></span>
-          <button onclick="incrementDate()">&gt;</button>
+          <button id="rightButton" class="disabled" onclick="incrementDate()">&gt;</button>
         </div>
         <div id="submissionCount"></div>
         <table id="logTable">


### PR DESCRIPTION
Mesmo com o _alert_, o usuário tá podendo avançar o dia - imagino que depois do #3 .

Agora botão da direita, quando o dia é o atual, fica cinza, com a classe "disabled" e, quando o usuário clica, não ocorre nada. Quando o dia é um anterior, a classe "disabled" é removida e o botão fica azul novamente.